### PR TITLE
Remove Poetry virtualenv configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ ENV PYTHON_VERSION=3.7 \
 # Install and configure Poetry
 RUN pip install poetry
 
-## Set Poetry to create venvs inside project directory
-RUN poetry config settings.virtualenvs.in-project true
-
 # Configure user, groups and working directory
 RUN useradd -u 1000 -ms /bin/bash python && \
   mkdir -p /home/python/app

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -14,9 +14,6 @@ ENV PYTHON_VERSION=3.7 \
 # Install and configure Poetry
 RUN pip install poetry
 
-## Set Poetry to create venvs inside project directory
-RUN poetry config settings.virtualenvs.in-project true
-
 # Configure user, groups and working directory
 RUN adduser -u 1000 -D python && \
   mkdir -p /home/python/app


### PR DESCRIPTION
Remove Poetry virtualenv configuration for project file be installed inside project folder.

This configuration only worked for the root user and the image provides a base user already, so the config is useless for most cases.